### PR TITLE
New GPU Memory data methods

### DIFF
--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -183,20 +183,19 @@ class NVDockerClient:
         gpu_memory_data = nvmlDeviceGetMemoryInfo(gpu_handle)
         rv = {}
         #returns in megabytes
-        rv["used"] = gpu_memory_data.used/1e6
-        rv["free"] = gpu_memory_data.free/1e6
+        rv["used_mb"] = gpu_memory_data.used/1e6
+        rv["free_mb"] = gpu_memory_data.free/1e6
         return rv
 
     @staticmethod
     def least_used_gpu():
-        gpus = NVDockerClient.get_gpus()
+        gpus = NVDockerClient.gpu_info()
         lowest_key = None;
-        for key in gpus.keys():
-            if lowest_key == None and gpus[key]['memory_free'] > 0:
-                lowest_key = key
-            elif gpus[key]['memory_free'] < gpus[lowest_keys]['memory_free']:
-                lowest_key = key
-            else:
-                pass
-
+        lowest_used_memory = 1e9;
+        for id in gpus.keys():
+            memory = NVDockerClient.gpu_memory_usage(id)["used_mb"]
+            if lowest_key is None or memory < lowest_used_memory:
+                lowest_key = id
+                lowest_used_memory = memory
         return lowest_key
+

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -3,7 +3,7 @@ import os
 from subprocess import check_output
 import re
 import docker
-from pynvml import *
+from py3nvml.py3nvml import *
 
 class NVDockerClient:
 
@@ -180,7 +180,12 @@ class NVDockerClient:
         if id not in gpus.keys():
             return None
         gpu_handle = gpus[id]["gpu_handle"]
-        return nvmlDeviceGetMemoryInfo(gpu_handle)
+        gpu_memory_data = nvmlDeviceGetMemoryInfo(gpu_handle)
+        rv = {}
+        #returns in megabytes
+        rv["used"] = gpu_memory_data.used/1e6
+        rv["free"] = gpu_memory_data.free/1e6
+        return rv
 
     @staticmethod
     def least_used_gpu():

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -176,10 +176,11 @@ class NVDockerClient:
 
     @staticmethod
     def gpu_memory_usage(id):
-        gpus = NVDockerClient.get_gpus()
+        gpus = NVDockerClient.gpu_info()
         if id not in gpus.keys():
             return None
-        return gpus[id]
+        gpu_handle = gpus[id]["gpu_handle"]
+        return nvmlDeviceGetMemoryInfo(gpu_handle)
 
     @staticmethod
     def least_used_gpu():

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -172,7 +172,21 @@ class NVDockerClient:
 
     @staticmethod
     def gpu_memory_usage(id):
-        gpus = NVDockerClient.get_gpus();
+        gpus = NVDockerClient.get_gpus()
         if id not in gpus.keys():
             return None
         return gpus[id]
+
+    @staticmethod
+    def least_used_gpu():
+        gpus = NVDockerClient.get_gpus()
+        lowest_key = None;
+        for key in gpus.keys():
+            if lowest_key == None and gpus[key]['memory_free'] > 0:
+                lowest_key = key
+            elif gpus[key]['memory_free'] < gpus[lowest_keys]['memory_free']:
+                lowest_key = key
+            else:
+                pass
+
+        return lowest_key

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -69,7 +69,7 @@ class NVDockerClient:
         #defaults
         config = {}
         environment = {}
-       for arg in kwargs:
+        for arg in kwargs:
             if arg == "driver_capabilities":
                 environment["NVIDIA_DRIVER_CAPABILITIES"] = kwargs["driver_capabilities"]
             elif arg == "visible_devices" in kwargs:

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -151,7 +151,7 @@ class NVDockerClient:
         return c.exec_run(cmd)
 
     @staticmethod
-    def get_gpus():
+    def gpu_info():
         #output = check_output(["nvidia-smi", "-L"]).decode("utf-8")
         keys = ['memory_free', 'memory_used', 'memory_total']
         query_gpu = check_output(["nvidia-smi", "--query-gpu=memory.free,memory.used,memory.total","--format=csv,noheader"]).decode("utf-8")

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -153,7 +153,7 @@ class NVDockerClient:
     @staticmethod
     def list_gpus():
         #output = check_output(["nvidia-smi", "-L"]).decode("utf-8")
-        query_gpu = check_output(["nvidia-smi", "--query-gpu=memory.free,memory.used,memory.total --format=csv,noheader"]).decode("utf-8");
+        query_gpu = check_output(["nvidia-smi", "--query-gpu=memory.free,memory.used,memory.total","--format=csv,noheader"]).decode("utf-8");
         #regex = re.compile(r"GPU (?P<id>\d+):")
         gpus = {}
         id = 0;
@@ -162,6 +162,7 @@ class NVDockerClient:
             for info in gpu:
                 gpu_info.append(info.split(" ")[0]);
             gpus[id] = gpu_info;
+            id += 1
         return gpus
 
     @staticmethod

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -153,7 +153,7 @@ class NVDockerClient:
     @staticmethod
     def list_gpus():
         #output = check_output(["nvidia-smi", "-L"]).decode("utf-8")
-        query_gpu = check_output("nvidia-smi", "--query-gpu=memory.free,memory.used,memory.total --format=csv,noheader")
+        query_gpu = check_output(["nvidia-smi", "--query-gpu=memory.free,memory.used,memory.total --format=csv,noheader"]).decode("utf-8");
         #regex = re.compile(r"GPU (?P<id>\d+):")
         gpus = {}
         id = 0;

--- a/nvdocker/nvdocker.py
+++ b/nvdocker/nvdocker.py
@@ -152,13 +152,16 @@ class NVDockerClient:
 
     @staticmethod
     def list_gpus():
-        output = check_output(["nvidia-smi", "-L"]).decode("utf-8") 
-        regex = re.compile(r"GPU (?P<id>\d+):")
-        gpus = []
-        for line in output.strip().split("\n"):
-            m = regex.match(line)
-            assert m, "unable to parse " + line
-            gpus.append(int(m.group("id")))
+        #output = check_output(["nvidia-smi", "-L"]).decode("utf-8")
+        query_gpu = check_output("nvidia-smi", "--query-gpu=memory.free,memory.used,memory.total --format=csv,noheader")
+        #regex = re.compile(r"GPU (?P<id>\d+):")
+        gpus = {}
+        id = 0;
+        for gpu in query_gpu.split("\n"):
+            gpu_info = []
+            for info in gpu:
+                gpu_info.append(info.split(" ")[0]);
+            gpus[id] = gpu_info;
         return gpus
 
     @staticmethod


### PR DESCRIPTION
Changed the nvidia-smi call to use the --query-gpu flag in order to only get the data that we need. the get_gpu() function now returns a dictionary of all the gpus and the memory data of each gpu; this can be extended to get other gpu data from nvidia-smi. Also updated the gpu_memory_usage to take an id parameter to get the memory usage of only one gpu.